### PR TITLE
Use natural sort order

### DIFF
--- a/lib/sort-js-object-core.js
+++ b/lib/sort-js-object-core.js
@@ -75,13 +75,14 @@ function sortObject(object, sortOrder) {
       return -1;
     }
 
-    return a.key.name
-      ? b.key.name
-        ? a.key.name.localeCompare(b.key.name)
-        : 1
-      : b.key.name
-        ? -1
-        : a.key.value.localeCompare(b.key.value);
+    const aKey = a.key.name || a.key.value || '';
+    const bKey = b.key.name || b.key.value || '';
+    const result = aKey.localeCompare(bKey, undefined, { numeric: true });
+
+    if (result !== 0 || !aKey || a.key.name && b.key.name) {
+      return result;
+    }
+    return a.key.name ? -1 : 1;
   });
 
   if (sortOrder && sortOrder.indexOf('desc') >= 0) {

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -299,10 +299,10 @@ suite('Extension Tests', function() {
     assert.equal(
       result,
       `{
-        'a': 1,
-        'b': 'test',
         a: 1,
-        b: 'test'
+        'a': 1,
+        b: 'test',
+        'b': 'test'
     }`
     );
   });
@@ -399,6 +399,23 @@ suite('Extension Tests', function() {
             name: 'Xingxin',
             age: 26
         } as IPerson)
+    }`
+    );
+  });
+
+  test('Sort in natural order', function() {
+    var jsObject = `{
+        a10b: 'teszt',
+        a2b: 2
+    }`;
+
+    var result = sorter.sort(jsObject,4, ['asc'], {});
+
+    assert.equal(
+      result,
+      `{
+        a2b: 2,
+        a10b: 'teszt'
     }`
     );
   });


### PR DESCRIPTION
The current implementation sorts keys with quotes before keys without quotes.
This PR changes this behavior to not differentiate between the two, and turns on the `numeric` collation.
