### PR TITLE
Enabling ES6 spread operator sorting

### DIFF
--- a/lib/sort-js-object-core.js
+++ b/lib/sort-js-object-core.js
@@ -86,12 +86,14 @@ function sortObjectNested(object, sortOrder) {
   sortObject(objectContainer, sortOrder);
 
   objectContainer.properties.forEach(property => {
-    if (property.value.type === 'ObjectExpression' || property.value.type === 'TSAsExpression') {
-      sortObjectNested(property.value, sortOrder);
-    } else if (property.value.type === 'ArrayExpression') {
-      property.value.elements.forEach(element => {
-        sortObjectNested(element, sortOrder);
-      })
+    if(property.value){
+      if (property.value.type === 'ObjectExpression' || property.value.type === 'TSAsExpression') {
+        sortObjectNested(property.value, sortOrder);
+      } else if (property.value.type === 'ArrayExpression') {
+        property.value.elements.forEach(element => {
+          sortObjectNested(element, sortOrder);
+        })
+      }
     }
   })
 }
@@ -132,7 +134,7 @@ function selectedTextToSortedText(selectedText, indent, sortOrder) {
   try {
     ast = parse(code, {
       sourceType: 'module',
-      plugins: ['typescript']
+      plugins: ['typescript', 'objectRestSpread']
     });
   } catch (e) {
     throw { message: 'Please make sure your selected text is a JS object!' };

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -506,4 +506,27 @@ suite('Extension Tests', function() {
     }`
     );
   });
+
+  test('normal js object with spread', function() {
+    var jsObject = `{
+        user: 'user',
+        aaa: 'aaa',
+        ...object,
+        bbb: 'bbb',
+        password: 'password'
+    }`;
+
+    var result = sorter.sort(jsObject, 4, ['asc'], {});
+
+    assert.equal(
+      result,
+      `{
+        aaa: 'aaa',
+        bbb: 'bbb',
+        password: 'password',
+        user: 'user',
+        ...object
+    }`
+    );
+  });
 });


### PR DESCRIPTION
Under the current plugins the babel parser cannot handle es6 spread operators when parsing the object to the ast. This PR includes the required plugin and adds a single spec.